### PR TITLE
Fixed issue loading episodes in Spike.

### DIFF
--- a/resources/lib/stations/spike.py
+++ b/resources/lib/stations/spike.py
@@ -48,6 +48,7 @@ def _get_manifest(page_url):
 			if ('triforceManifestFeed') in script.string:
 				triforceManifestFeed = script.string.split(' = ')[1]
 				triforceManifestFeed = triforceManifestFeed.strip()[:-1]
+				triforceManifestFeed = triforceManifestFeed.split(';')[0]
 				triforceManifestFeed = simplejson.loads(triforceManifestFeed)
 				return triforceManifestFeed
 	except:


### PR DESCRIPTION
The script section with the manifest json included an extra variable that was causing the parser to throw an exception.  Grabbing the content until the semicolon includes only the relevant information.