### PR TITLE
Updated signature url for A&E Network playback

### DIFF
--- a/resources/lib/main_aenetwork.py
+++ b/resources/lib/main_aenetwork.py
@@ -244,5 +244,7 @@ def convert_subtitles(closedcaption):
 	return True
 
 def sign_url(url):
-	sig = connection.getURL('http://www.history.com/components/get-signed-signature?url=' + re.compile('/[sz]/(.+)\?').findall(url)[0])
+	query = { 'url' : re.compile('/[sz]/(.+)\?').findall(url)[0] }
+	encoded = urllib.urlencode(query)
+	sig = connection.getURL('http://servicesaetn-a.akamaihd.net/jservice/video/components/get-signed-signature?' + encoded)
 	return sig


### PR DESCRIPTION
The old signature url was invalid.  A&E has a new url for generating the signature along with different encoding requirements which was fixed in this fork.